### PR TITLE
Show default author name (It's quiz user) on activation page

### DIFF
--- a/shared/utils/apiResponseFormatter.js
+++ b/shared/utils/apiResponseFormatter.js
@@ -1,7 +1,3 @@
-import { backgroundImagesPrefix } from '../config';
-
-const NUMBER_OF_BACKGROUNDS = 12;
-
 export default {
     formatActivation(activation, author) {
         return {
@@ -104,12 +100,5 @@ export default {
         }
 
         return 'verybad';
-    },
-
-    _getBackgpoundURLById(id) {
-        const number = parseInt(id, 16);
-        const backgroundNumber = number % NUMBER_OF_BACKGROUNDS + 1;
-
-        return `${backgroundImagesPrefix}${backgroundNumber}.jpg`;
     }
 };

--- a/shared/utils/apiResponseFormatter.js
+++ b/shared/utils/apiResponseFormatter.js
@@ -76,8 +76,14 @@ export default {
         };
     },
 
-    _getUserFullName(user) {
-        return user.type === 'COMPANY' ? user.companyName : `${user.firstName} ${user.secondName}`;
+    _getUserFullName({ firstName, secondName, ...user }) {
+        if (user.type === 'COMPANY') {
+            return user.companyName;
+        }
+
+        return firstName || secondName
+            ? `${firstName}  ${secondName}`
+            : 'It`s quiz user';
     },
 
     _getResultGrade(score) {


### PR DESCRIPTION
 Show default author name (It's quiz user) on activation page in case author hasn't indicated his real name
![same_author_quizzes](https://cloud.githubusercontent.com/assets/17126360/13493765/c8f9f162-e148-11e5-80c7-21a4c2f864b8.png)

