### PR TITLE
Add links truncation if max length exceeded

### DIFF
--- a/shared/components/Markdown.jsx
+++ b/shared/components/Markdown.jsx
@@ -1,5 +1,8 @@
  /* eslint
-    react/no-danger: 0
+    react/no-danger: 0,
+    max-params: 0,
+    func-style: 0,
+    camelcase: 0
 */
 
 import React, { Component, PropTypes } from 'react';
@@ -7,6 +10,8 @@ import React, { Component, PropTypes } from 'react';
 import { activationDescriptionPreset } from './Markdown/presets.js';
 
 import MarkdownIt from 'markdown-it';
+
+const MAX_LINK_LENGTH = 25;
 
 class Markdown extends Component {
 
@@ -21,6 +26,31 @@ class Markdown extends Component {
     componentWillMount() {
         this.md = new MarkdownIt();
         this.md.configure(activationDescriptionPreset).enable('linkify').enable(['link', 'list', 'emphasis']);
+
+        const customRenderer = (tokens, idx, options, env, self) => self.renderToken(tokens, idx, options);
+        const defaultRender = this.md.renderer.rules.link_open || customRenderer;
+
+        this.md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+            const newTokens = tokens;
+            const aIndex = newTokens[idx].attrIndex('target');
+
+            if (aIndex < 0) {
+                newTokens[idx].attrPush(['target', '_blank']);
+            } else {
+                newTokens[idx].attrs[aIndex][1] = '_blank';
+            }
+
+            if (newTokens[idx].info === 'auto') {
+                let href = newTokens[idx].attrs[0][1];
+
+                if (href.length > MAX_LINK_LENGTH) {
+                    href = `${href.slice(0, MAX_LINK_LENGTH)}...`;
+                    newTokens[idx + 1].content = href;
+                }
+            }
+
+            return defaultRender(newTokens, idx, options, env, self);
+        };
     }
 
     getMarkdownMarkup = () => {


### PR DESCRIPTION
On activation page in description section adds links truncation if max length exceeded
![screenshot from 2016-03-09 15 42 25](https://cloud.githubusercontent.com/assets/17126360/13637015/abb13b82-e60d-11e5-8ff1-167d8d9f9a1c.png)