### PR TITLE
18712 - Display greeting description instead of activation description on activation page

### DIFF
--- a/shared/components/pages/ActivationPage.jsx
+++ b/shared/components/pages/ActivationPage.jsx
@@ -13,7 +13,6 @@ import ShareDialog          from '../../containers/ShareDialog.jsx';
 import LoginDialog          from '../../containers/LoginDialog.jsx';
 import AppBarWithBackground from '../AppBarWithBackground.jsx';
 import ExpandableText       from '../ExpandableText.jsx';
-import Dialog               from '../Dialog.jsx';
 
 import { sprintf } from '../../utils';
 
@@ -199,41 +198,6 @@ export default class ActivationPage extends React.Component {
         return null;
     };
 
-    renderGreetingPhrase = () => {
-        const { l } = this.context.i18n;
-
-        const userScore = this.props.activation.userQuizSession.score;
-        const greeting = this.getGreeting(userScore);
-
-        return (
-            <div className='ActivationsPage__greeting-wrapper'>
-                <h4 className='ActivationPage__greeting'>
-                    {greeting.phrase}
-                </h4>
-
-                {
-                    greeting.description
-                    ?
-                        <span
-                            className='ActivationsPage__greeting-description'
-                            onClick={this.handleDescriptionClick}
-                        >
-                            {l('View description')}
-                        </span>
-                    :
-                        null
-                }
-
-                <Dialog
-                    isOpen         = {this.state.showDescription}
-                    onRequestClose = {this.handleHideDescription}
-                >
-                    <p className='ActivationPage__greeting-description'>{greeting.description}</p>
-                </Dialog>
-            </div>
-        );
-    };
-
     renderContent = () => {
         const {
             activation,
@@ -265,6 +229,9 @@ export default class ActivationPage extends React.Component {
         const { l, ngettext, humanizeDuration, getTimeFromNow } = this.context.i18n;
 
         const isPassingBtnAvailable = isEmbedded ? canAssigneePass : true;
+
+        const greeting = showUserResult ? this.getGreeting(userQuizSession.score).phrase : null;
+        const isGreetingDescrAvailable = showUserResult ? this.getGreeting(userQuizSession.score).description : false;
 
         if (isLoading) {
             return <Spinner className='ActivationPage__spinner' />;
@@ -405,7 +372,9 @@ export default class ActivationPage extends React.Component {
                                 <div className='ActivationPage__overlay'>
                                     <div className='ActivationPage__results-text'>
 
-                                        {this.renderGreetingPhrase()}
+                                        <h4 className='ActivationPage__greeting'>
+                                            {greeting}
+                                        </h4>
 
                                         <div className='ActivationPage__score'>
                                             {userQuizSession.score}%
@@ -472,7 +441,7 @@ export default class ActivationPage extends React.Component {
                     <div className='ActivationPage__details'>
                         <ExpandableText
                             isMarkdownEnabled
-                            text={activation.message}
+                            text={isGreetingDescrAvailable ? isGreetingDescrAvailable : activation.message}
                             markdownPreset='activationDescription'
                         />
                     </div>

--- a/shared/components/pages/ActivationPage.jsx
+++ b/shared/components/pages/ActivationPage.jsx
@@ -230,8 +230,8 @@ export default class ActivationPage extends React.Component {
 
         const isPassingBtnAvailable = isEmbedded ? canAssigneePass : true;
 
-        const greeting = showUserResult ? this.getGreeting(userQuizSession.score).phrase : null;
-        const greetingDescription = showUserResult ? this.getGreeting(userQuizSession.score).description : false;
+        const greeting = showUserResult ? this.getGreeting(userQuizSession.score).phrase : '';
+        const greetingDescription = showUserResult ? this.getGreeting(userQuizSession.score).description : '';
 
         if (isLoading) {
             return <Spinner className='ActivationPage__spinner' />;
@@ -441,7 +441,7 @@ export default class ActivationPage extends React.Component {
                     <div className='ActivationPage__details'>
                         <ExpandableText
                             isMarkdownEnabled
-                            text={greetingDescription ? greetingDescription : activation.message}
+                            text={greetingDescription || activation.message}
                             markdownPreset='activationDescription'
                         />
                     </div>

--- a/shared/components/pages/ActivationPage.jsx
+++ b/shared/components/pages/ActivationPage.jsx
@@ -231,7 +231,7 @@ export default class ActivationPage extends React.Component {
         const isPassingBtnAvailable = isEmbedded ? canAssigneePass : true;
 
         const greeting = showUserResult ? this.getGreeting(userQuizSession.score).phrase : null;
-        const isGreetingDescrAvailable = showUserResult ? this.getGreeting(userQuizSession.score).description : false;
+        const greetingDescription = showUserResult ? this.getGreeting(userQuizSession.score).description : false;
 
         if (isLoading) {
             return <Spinner className='ActivationPage__spinner' />;
@@ -441,7 +441,7 @@ export default class ActivationPage extends React.Component {
                     <div className='ActivationPage__details'>
                         <ExpandableText
                             isMarkdownEnabled
-                            text={isGreetingDescrAvailable ? isGreetingDescrAvailable : activation.message}
+                            text={greetingDescription ? greetingDescription : activation.message}
                             markdownPreset='activationDescription'
                         />
                     </div>


### PR DESCRIPTION
Earlier
![screenshot from 2016-04-29 14 50 24](https://cloud.githubusercontent.com/assets/17126360/14915203/be3f3a36-0e19-11e6-8baf-cb2a8adc4b19.png)

Now
![screenshot from 2016-04-29 14 48 07](https://cloud.githubusercontent.com/assets/17126360/14915175/79fe6b1c-0e19-11e6-99b4-06c963cc3bb3.png)
