### PR TITLE
Fix error for new eslint rule "no-c-like-loops"

### DIFF
--- a/shared/reducers/activations.js
+++ b/shared/reducers/activations.js
@@ -28,7 +28,7 @@ export default function activations(state = DEFAULT_STATE, action) {
                 ? state.entitiesByCategory[action.category].slice(0)
                 : [];
 
-            for (let i = 0; i < newActivations.length; i++) {
+            for (const i in newActivations) {
                 if (action.offset + i < loadedActivations.length) {
                     loadedActivations[action.offset + i] = newActivations[i];
                 } else {


### PR DESCRIPTION
When I clone it and `npm run webpack-devserver`, I hit an error.

> ERROR in ./shared/reducers/activations.js
>  .../itsquiz-wall/shared/reducers/activations.js
> 31:13  error  Do not use c-like loop with i++ or i +=1, instead use forEach, Map, or For of  more/no-c-like-loops
> ✖ 1 problem (1 error, 0 warnings)

So I fix it.